### PR TITLE
mem_free for osx

### DIFF
--- a/cmds.py
+++ b/cmds.py
@@ -19,8 +19,10 @@ def cmd_cpu_idle(args):
 
 
 def cmd_mem_free(args):
-    return subprocess.check_output('vmstat').splitlines()[-1].split()[3]
-
+    if _platform() == "darwin":
+        return subprocess.check_output('vm_stat').splitlines()[1].split()[2]
+    else:
+        return subprocess.check_output('vmstat').splitlines()[-1].split()[3]
 
 def cmd_cpu_temp(args):
     return subprocess.check_output(('sysctl', '-n', 'hw.sensors.cpu0.temp0'))


### PR DESCRIPTION
@ccstolley Added `mem_free_osx()` function for OSX in order to get the same memory usage that `vmstat` gives you on UNIX like systems(Linux, FreeBSD, Solaris etc..)

**Sample Usage**

`printf "mem_free_osx\n" | nc localhost 7000`
