### PR TITLE
fix variables in the printf format string

### DIFF
--- a/smoke_test.sh
+++ b/smoke_test.sh
@@ -9,7 +9,7 @@ if [ X"$commands" = X ]; then
 fi
 
 for cmd in $commands; do
-    val=$(printf "$cmd\n"| nc localhost 7000)
+    val=$(printf "%s\n" "$cmd" | nc localhost 7000)
     if [ X"$val" = X -o X"$val" = Xerror ]; then
         echo "$cmd is broken"
         tests_ok=0


### PR DESCRIPTION
Hey @ccstolley this is pretty nit picky. Bu I decided to issue a PR for some of the tests created in the shell script. This is pretty much a shell best practice technique I wanted to fix. 

`printf` interprets escape sequences and format specifiers in the format string. If variables are included, any escape sequences or format specifiers in the data will be interpreted too, when you most likely wanted to treat it as data.
